### PR TITLE
Add support for /r/megalinks2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
   "content_scripts": [{
         "matches": [
             "https://forum.snahp.it/viewtopic.php*",
-            "https://*.reddit.com/r/megalinks/comments/*"
+            "https://*.reddit.com/r/megalinks2/comments/*"
         ],
         "js": [ "forum/index.js" ],
         "css": [ "forum/style.css" ]

--- a/manifest.json
+++ b/manifest.json
@@ -10,8 +10,7 @@
   },
   "content_scripts": [{
         "matches": [
-            "https://forum.snahp.it/viewtopic.php*",
-            "https://*.reddit.com/r/megalinks2/comments/*"
+            "https://forum.snahp.it/viewtopic.php*"
         ],
         "js": [ "forum/index.js" ],
         "css": [ "forum/style.css" ]


### PR DESCRIPTION
The old /r/megalinks subreddit has been deprecated, so switch to supporting /r/megalinks2 instead.

Fixes #1.