### PR TITLE
Add Userscript for Other Browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# Chrome Extension | MegaLinks & Snahp.it Forum Link Solver
+# MegaLinks & Snahp Forum Link Solver
 
-Simplify opening forum.snahp.it (snahp.eu) links.
+Simplify opening forum.snahp.it (fora.snahp.eu) links.
 
-_Snahp.it Forum Link Solver_ automatically finds all Snahp forum post links including:
+# About
+
+_Snahp Forum Link Solver_ automatically finds all Snahp forum post links including:
 
 * Mega.nz
 * Snahp.it Link Protector
@@ -11,6 +13,11 @@ _Snahp.it Forum Link Solver_ automatically finds all Snahp forum post links incl
 
 whether they're hotlinks, plain text, or base64 encoded.
 
-_Mega.nz_ and _Snahp.it Link Protector_ passwords are also copied and automatically entered.
+_Mega.nz_ and _Snahp Link Protector_ passwords are also copied and automatically entered.
 
 All links are displayed in a friendly on-screen popup.
+
+# Download
+
+* [Chrome Extension](https://chrome.google.com/webstore/detail/snahp-forum-link-solver/mdpijnoimlepjlncbjdbnhecfhnlfiib) -- For Google Chrome and compatible browsers (e.g. Brave, Opera, Vivaldi)
+* [Userscript](https://github.com/andrewjmetzger/snahp-it-forum-link-solver/raw/userscript/solver.user.js) -- For all Browsers, requires a UserScript manager like [Violentmonkey](https://violentmonkey.github.io/) or Tampermonkey

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Simplify opening forum.snahp.it (fora.snahp.eu) links.
 
+# Download
+
+* [Chrome Extension](https://chrome.google.com/webstore/detail/snahp-forum-link-solver/mdpijnoimlepjlncbjdbnhecfhnlfiib) -- For Google Chrome and compatible browsers (e.g. Brave, Opera, Vivaldi)
+* [Userscript](https://github.com/andrewjmetzger/snahp-it-forum-link-solver/raw/userscript/solver.user.js) -- For all Browsers, requires a UserScript manager like [Violentmonkey](https://violentmonkey.github.io/) or Tampermonkey
+
 # About
 
 _Snahp Forum Link Solver_ automatically finds all Snahp forum post links including:
@@ -16,8 +21,3 @@ whether they're hotlinks, plain text, or base64 encoded.
 _Mega.nz_ and _Snahp Link Protector_ passwords are also copied and automatically entered.
 
 All links are displayed in a friendly on-screen popup.
-
-# Download
-
-* [Chrome Extension](https://chrome.google.com/webstore/detail/snahp-forum-link-solver/mdpijnoimlepjlncbjdbnhecfhnlfiib) -- For Google Chrome and compatible browsers (e.g. Brave, Opera, Vivaldi)
-* [Userscript](https://github.com/andrewjmetzger/snahp-it-forum-link-solver/raw/userscript/solver.user.js) -- For all Browsers, requires a UserScript manager like [Violentmonkey](https://violentmonkey.github.io/) or Tampermonkey

--- a/solver.user.js
+++ b/solver.user.js
@@ -1,11 +1,11 @@
 // ==UserScript==
 // @name          Snahp Forum Link Solver
 // @namespace     https://github.com/samvk/
-// @version       1.0.1
-// @author        samvk
-// @author        andrewjmetzger
+// @version       1.0.2
+// @author        samvk, andrewjmetzger
 // @description   Automatically find and decode Snahp forum post links.
 //
+// @homepageURL https://github.com/samvk/snahp-it-forum-link-solver
 // @downloadURL https://github.com/andrewjmetzger/snahp-it-forum-link-solver/raw/userscript/solver.user.js
 // @updateURL   https://github.com/andrewjmetzger/snahp-it-forum-link-solver/raw/userscript/solver.user.js
 // @supportURL  https://github.com/andrewjmetzger/snahp-it-forum-link-solver/issues

--- a/solver.user.js
+++ b/solver.user.js
@@ -1,15 +1,15 @@
 // ==UserScript==
 // @name          Snahp Forum Link Solver
 // @namespace     https://github.com/samvk/
-// @version       1.0.0
+// @version       1.0.1
 // @author        samvk
 // @author        andrewjmetzger
 // @description   Automatically find and decode Snahp forum post links.
 //
-// @downloadURL
-// @updateURL
-// @supportURL
-// 
+// @downloadURL https://github.com/andrewjmetzger/snahp-it-forum-link-solver/raw/userscript/solver.user.js
+// @updateURL   https://github.com/andrewjmetzger/snahp-it-forum-link-solver/raw/userscript/solver.user.js
+// @supportURL  https://github.com/andrewjmetzger/snahp-it-forum-link-solver/issues
+//
 // @match         *://fora.snahp.eu/viewtopic.php*
 // @math          *://links.snahp.eu/*
 // 

--- a/solver.user.js
+++ b/solver.user.js
@@ -1,0 +1,57 @@
+// ==UserScript==
+// @name          Snahp Forum Link Solver
+// @namespace     https://github.com/samvk/
+// @version       1.0.0
+// @author        samvk
+// @author        andrewjmetzger
+// @description   Automatically find and decode Snahp forum post links.
+//
+// @downloadURL
+// @updateURL
+// @supportURL
+// 
+// @match         *://fora.snahp.eu/viewtopic.php*
+// @math          *://links.snahp.eu/*
+// 
+// @require       https://raw.githubusercontent.com/samvk/snahp-it-forum-link-solver/master/forum/index.js
+// @require       https://raw.githubusercontent.com/samvk/snahp-it-forum-link-solver/master/links/index.js
+// 
+// @resource      forum_css https://raw.githubusercontent.com/samvk/snahp-it-forum-link-solver/master/forum/style.css
+// @resource      links_css https://raw.githubusercontent.com/samvk/snahp-it-forum-link-solver/master/links/style.css
+// 
+// @grant         GM_xmlhttpRequest
+// @grant         GM_getResourceText
+// @grant         GM_addStyle
+// ==/UserScript==
+
+(function () {
+    'use strict';
+
+    let subdomain = window.location.host.split(".")[0];
+    let githubDirectory = '';
+
+    if (subdomain == 'fora') {
+        githubDirectory = 'forum';
+    } else if (subdomain == 'links') {
+        githubDirectory = 'links';
+    }
+    else { console.error('Snahp Forum Link Solver: Could not detect subdomain!'); }
+
+    // Load remote JS
+    GM_xmlhttpRequest({
+        method: "GET",
+        url: "https://raw.githubusercontent.com/samvk/snahp-it-forum-link-solver/master/" + githubDirectory + "/index.js",
+        onload: (ev) => {
+            let e = document.createElement('script');
+            e.innerText = ev.responseText;
+            document.head.appendChild(e);
+        }
+    });
+
+    // Load remote CSS
+    // @see https://github.com/Tampermonkey/tampermonkey/issues/835
+    const myCss = GM_getResourceText(githubDirectory + "_css");
+    GM_addStyle(myCss);
+
+
+})();


### PR DESCRIPTION
# What is this?

This PR adds a userscript version of the Snahp Forum Link Solver (`solver.user.js`) to enable compatibility with browsers other than Google Chrome et al. Userscripts can be run in virtually any browser with a userscript manager like [Violentmonkey](https://violentmonkey.github.io/). I have added Violentmonkey as a recommendation based on personal experience (this PR was validated in Violentmonkey).

# How it works

This userscript was fairly easy to write. It avoids duplicate work by pulling in the existing JS and CSS files already used by the Google Chrome extension, with minimal wrapper logic to load the correct script for `links.snahp.eu` or `fora.snahp.eu`. 

Future versions of the Chrome extension should not require any changes beyond a version bump in the Userscript header (which contains similar information to `manifest.json`). Should something break, though, I'm happy to help.

# Other changes

* Updated the README to remove some `snahp.it` references
* Added a **Downloads** section to the README, containing links to the Chrome extension and Userscript
